### PR TITLE
Add timestamp to server startup message

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -135,6 +135,7 @@ export class TargetProcessServer {
   async run() {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    console.error('Target Process MCP server running on stdio');
+    const timestamp = new Date().toISOString();
+    console.error(`Target Process MCP server running on stdio (started at ${timestamp})`);
   }
 }


### PR DESCRIPTION
This PR adds a timestamp to the server startup message to make it easier to track when the server was started.