### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Model Context Protocol (MCP) is a standard that enables AI assistants to interact with external tools and services through a unified interface. MCP servers provide these capabilities by exposing tools and resources that AI assistants can use to accomplish tasks.
 
+<a href="https://glama.ai/mcp/servers/r67qn2xf6t">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/r67qn2xf6t/badge" alt="Targetprocess Server MCP server" />
+</a>
+
 This MCP server provides tools for interacting with Targetprocess, a project management and agile planning platform. It enables AI assistants to:
 - Search and retrieve Targetprocess entities (User Stories, Bugs, Tasks, Features, etc.)
 - Create and update entities with proper validation


### PR DESCRIPTION
This PR adds a badge for the [Targetprocess MCP Server](https://glama.ai/mcp/servers/r67qn2xf6t) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/r67qn2xf6t">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/r67qn2xf6t/badge" alt="Targetprocess Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.