### PR TITLE
Add TimeSheet as valid entity type and bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TargetProcessMCP",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A tool server for Apptio Target Process",
   "private": true,
   "type": "module",

--- a/src/entities/base/base.types.ts
+++ b/src/entities/base/base.types.ts
@@ -54,7 +54,8 @@ export type ResourceType =
   | 'Process'
   | 'GeneralUser'
   | 'Comment'
-  | 'Attachment';
+  | 'Attachment'
+  | 'TimeSheet';
 
 export interface BaseEntityData {
   Id: number;

--- a/src/tools/search/search.tool.ts
+++ b/src/tools/search/search.tool.ts
@@ -41,7 +41,7 @@ export const searchToolSchema = z.object({
     'Epic', 'PortfolioEpic', 'Solution', 
     'Request', 'Impediment', 'TestCase', 'TestPlan',
     'Project', 'Team', 'Iteration', 'TeamIteration',
-    'Release', 'Program'
+    'Release', 'Program', 'TimeSheet'
   ]),
   where: z.string().optional().describe('Filter expression or use searchPresets for common filters'),
   include: z.array(z.string()).optional().describe('Related data to include (e.g., Project, Team, AssignedUser)'),
@@ -109,7 +109,7 @@ export class SearchTool {
               'Epic', 'PortfolioEpic', 'Solution', 
               'Request', 'Impediment', 'TestCase', 'TestPlan',
               'Project', 'Team', 'Iteration', 'TeamIteration',
-              'Release', 'Program'
+              'Release', 'Program', 'TimeSheet'
             ],
             description: 'Type of entity to search',
           },


### PR DESCRIPTION
This PR adds 'TimeSheet' as a valid entity type in the search tool schema and ResourceType. It also bumps the version to 0.1.1.

Changes:
- Added 'TimeSheet' to the search tool schema in src/tools/search/search.tool.ts
- Added 'TimeSheet' to the tool definition in the same file
- Added 'TimeSheet' to the ResourceType type in src/entities/base/base.types.ts
- Bumped version from 0.1.0 to 0.1.1 in package.json