### PR TITLE
Feature/add timesheet entity type

### DIFF
--- a/src/api/client/tp.service.ts
+++ b/src/api/client/tp.service.ts
@@ -279,7 +279,8 @@ export class TPService {
       'Request', 'Impediment', 'TestCase', 'TestPlan',
       'Project', 'Team', 'Iteration', 'TeamIteration',
       'Release', 'Program', 'Comment', 'Attachment',
-      'EntityState', 'Priority', 'Process', 'GeneralUser'
+      'EntityState', 'Priority', 'Process', 'GeneralUser',
+      'TimeSheet'
     ];
     
     try {

--- a/src/api/client/tp.service.ts
+++ b/src/api/client/tp.service.ts
@@ -364,7 +364,9 @@ export class TPService {
       }
 
       return await this.executeWithRetry(async () => {
-        const response = await fetch(`${this.baseUrl}/${validatedType}s?${params}`, {
+        // Special case for TimeSheet entity which uses 'time' endpoint instead of 'TimeSheets'
+        const endpoint = validatedType === 'TimeSheet' ? 'time' : `${validatedType}s`;
+        const response = await fetch(`${this.baseUrl}/${endpoint}?${params}`, {
           headers: {
             'Authorization': `Basic ${this.auth}`,
             'Accept': 'application/json'
@@ -410,7 +412,9 @@ export class TPService {
       }
 
       return await this.executeWithRetry(async () => {
-        const response = await fetch(`${this.baseUrl}/${validatedType}s/${id}?${params}`, {
+        // Special case for TimeSheet entity which uses 'time' endpoint instead of 'TimeSheets'
+        const endpoint = validatedType === 'TimeSheet' ? 'time' : `${validatedType}s`;
+        const response = await fetch(`${this.baseUrl}/${endpoint}/${id}?${params}`, {
           headers: {
             'Authorization': `Basic ${this.auth}`,
             'Accept': 'application/json'
@@ -446,7 +450,9 @@ export class TPService {
       const validatedType = await this.validateEntityType(type);
       
       return await this.executeWithRetry(async () => {
-        const response = await fetch(`${this.baseUrl}/${validatedType}s`, {
+        // Special case for TimeSheet entity which uses 'time' endpoint instead of 'TimeSheets'
+        const endpoint = validatedType === 'TimeSheet' ? 'time' : `${validatedType}s`;
+        const response = await fetch(`${this.baseUrl}/${endpoint}`, {
           method: 'POST',
           headers: {
             'Authorization': `Basic ${this.auth}`,
@@ -486,7 +492,9 @@ export class TPService {
       const validatedType = await this.validateEntityType(type);
       
       return await this.executeWithRetry(async () => {
-        const response = await fetch(`${this.baseUrl}/${validatedType}s/${id}`, {
+        // Special case for TimeSheet entity which uses 'time' endpoint instead of 'TimeSheets'
+        const endpoint = validatedType === 'TimeSheet' ? 'time' : `${validatedType}s`;
+        const response = await fetch(`${this.baseUrl}/${endpoint}/${id}`, {
           method: 'POST',
           headers: {
             'Authorization': `Basic ${this.auth}`,


### PR DESCRIPTION
'TimeSheet' is recognized as a valid entity type throughout the application
API requests for TimeSheet entities use the correct endpoint ('time' instead of 'TimeSheets')