### PR TITLE
Update Dependencies and Bump Version to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "TargetProcessMCP",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "TargetProcessMCP",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.9.0",
-        "axios": "^1.7.9",
+        "@modelcontextprotocol/sdk": "1.11.1",
+        "axios": "^1.9.0",
         "node-fetch": "^3.3.2",
-        "zod": "^3.24.2"
+        "zod": "^3.24.4"
       },
       "bin": {
         "TargetProcessMCP": "build/index.js"
@@ -1249,9 +1249,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.9.0.tgz",
-      "integrity": "sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.1.tgz",
+      "integrity": "sha512-9LfmxKTb1v+vUS1/emSk1f5ePmTLkb9Le9AxOB5T0XM59EUumwcS45z05h7aiZx3GI0Bl7mjb3FMEglYj+acuQ==",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -1819,9 +1819,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -6263,9 +6263,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TargetProcessMCP",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A tool server for Apptio Target Process",
   "private": true,
   "type": "module",
@@ -19,10 +19,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.9.0",
-    "axios": "^1.7.9",
+    "@modelcontextprotocol/sdk": "1.11.1",
+    "axios": "^1.9.0",
     "node-fetch": "^3.3.2",
-    "zod": "^3.24.2"
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
## Overview
This PR updates dependencies to their latest versions and bumps the package version to 0.2.0.

## Changes
- Update @modelcontextprotocol/sdk from 1.9.0 to 1.11.1
- Update axios to latest version 1.9.0
- Update zod to latest version 3.24.4
- Bump package version to 0.2.0

## Benefits
- Takes advantage of the latest features and improvements in the MCP SDK
- Addresses any security fixes in the updated dependencies
- Prepares for future features with semantic versioning