### PR TITLE
feat: Add hypothetical IBM Watson Orchestrate registry

### DIFF
--- a/mcp-registries/registries.yaml
+++ b/mcp-registries/registries.yaml
@@ -15,6 +15,12 @@ registries:
     config_file: cprime.yaml
     description: "Cprime MCP Registry"
     
+  - name: watson.orchestrate.ibm.com
+    branch: watson-orchestrate
+    directory: watson-orchestrate
+    config_file: watson-orchestrate.yaml
+    description: "IBM Watson Orchestrate MCP Registry (Hypothetical)"
+    
   # Example of adding another registry:
   # - name: another-registry.com
   #   branch: another-registry

--- a/mcp-registries/watson-orchestrate/watson-orchestrate.yaml
+++ b/mcp-registries/watson-orchestrate/watson-orchestrate.yaml
@@ -1,0 +1,120 @@
+# IBM Watson Orchestrate MCP Registry Configuration
+# This is a hypothetical configuration for Watson Orchestrate
+# Based on typical IBM enterprise integration patterns
+
+metadata:
+  name: "TargetProcess MCP Server"
+  version: "1.0.0"
+  description: "Enterprise-grade TargetProcess integration for Watson Orchestrate"
+  vendor: "Aaron Bockelie"
+  category: "Project Management"
+  tags:
+    - "targetprocess"
+    - "agile"
+    - "project-management"
+    - "task-tracking"
+    - "enterprise"
+
+authentication:
+  type: "environment"
+  required_vars:
+    - name: "TP_DOMAIN"
+      description: "TargetProcess instance domain"
+      type: "string"
+      required: true
+    - name: "TP_USERNAME"
+      description: "TargetProcess username"
+      type: "string"
+      required: true
+    - name: "TP_PASSWORD"
+      description: "TargetProcess password"
+      type: "string"
+      sensitive: true
+      required: true
+  optional_vars:
+    - name: "TP_USER_ROLE"
+      description: "User role for semantic operations"
+      type: "string"
+      default: "developer"
+      options: ["developer", "project-manager", "tester"]
+    - name: "TP_USER_ID"
+      description: "TargetProcess user ID for assignments"
+      type: "string"
+    - name: "TP_USER_EMAIL"
+      description: "User email for identification"
+      type: "string"
+
+deployment:
+  type: "container"
+  image: "ghcr.io/aaronsb/apptio-target-process-mcp:latest"
+  command: ["node", "build/index.js"]
+  resources:
+    memory: "256Mi"
+    cpu: "0.5"
+  environment:
+    - name: "MCP_STRICT_MODE"
+      value: "true"
+    - name: "NODE_ENV"
+      value: "production"
+
+capabilities:
+  tools:
+    - name: "search_entities"
+      description: "Search TargetProcess entities with advanced filtering"
+      category: "query"
+    - name: "get_entity"
+      description: "Retrieve detailed entity information"
+      category: "query"
+    - name: "create_entity"
+      description: "Create new TargetProcess entities"
+      category: "modify"
+    - name: "update_entity"
+      description: "Update existing entities"
+      category: "modify"
+    - name: "inspect_object"
+      description: "Inspect TargetProcess object schemas"
+      category: "metadata"
+  
+  semantic_operations:
+    - name: "show_my_tasks"
+      description: "View assigned tasks with intelligent filtering"
+      roles: ["developer", "project-manager", "tester"]
+    - name: "start_working_on"
+      description: "Begin work with automatic state transitions"
+      roles: ["developer", "tester"]
+    - name: "complete_task"
+      description: "Mark tasks complete with time tracking"
+      roles: ["developer", "tester"]
+    - name: "show_my_bugs"
+      description: "Analyze assigned bugs with severity insights"
+      roles: ["developer", "tester"]
+    - name: "log_time"
+      description: "Record time with intelligent discovery"
+      roles: ["developer", "project-manager", "tester"]
+
+integration:
+  watson_assistant:
+    enabled: true
+    intents:
+      - "project_status"
+      - "task_management"
+      - "bug_tracking"
+      - "time_logging"
+  
+  watson_discovery:
+    enabled: true
+    collections:
+      - "targetprocess_entities"
+      - "project_documentation"
+
+compliance:
+  data_residency: "configurable"
+  encryption: "in-transit"
+  audit_logging: true
+  gdpr_compliant: true
+  soc2_compliant: true
+
+support:
+  documentation: "https://github.com/aaronsb/apptio-target-process-mcp/tree/watson-orchestrate"
+  issues: "https://github.com/aaronsb/apptio-target-process-mcp/issues"
+  contact: "aaron@aaronsb.com"


### PR DESCRIPTION
## Summary
Adds a hypothetical IBM Watson Orchestrate MCP registry configuration to demonstrate enterprise integration patterns.

## Configuration Details

### Watson Orchestrate YAML Structure
Created an enterprise-focused configuration that includes:

1. **Metadata Section**
   - Vendor information (Aaron Bockelie)
   - Category and tagging for discovery
   - Version management

2. **Authentication**
   - Environment variable based authentication
   - Required and optional variables
   - Sensitive data handling

3. **Deployment**
   - Container-based deployment
   - Resource specifications
   - Production environment settings

4. **Capabilities**
   - Core tools categorized by function
   - Semantic operations with role-based access
   - Detailed descriptions for each capability

5. **Integration**
   - Watson Assistant integration points
   - Watson Discovery collections
   - Enterprise service connections

6. **Compliance**
   - Data residency options
   - Encryption requirements
   - Audit logging
   - GDPR and SOC2 compliance flags

### Why This Example?
- Shows how enterprise registries might structure their configurations
- Demonstrates advanced features like compliance and integration sections
- Provides a template for other enterprise MCP registries
- Illustrates IBM's typical configuration patterns

## Testing
- All tests pass with `./scripts/test-registry-config.sh`
- Configuration properly validated
- Ready for automatic branch creation

## Note
This is a **hypothetical example** - IBM Watson Orchestrate doesn't currently have an MCP registry. This serves as a demonstration of how enterprise registries could be configured.

🤖 Generated with [Claude Code](https://claude.ai/code)