### PR TITLE
fix: Remove path exclusions from registry sync workflow

### DIFF
--- a/.github/workflows/sync-mcp-registries.yml
+++ b/.github/workflows/sync-mcp-registries.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      # Trigger on any changes except the registry config files themselves
-      - '**'
-      - '!mcp-registries/**'
-      - '!.github/workflows/sync-mcp-registries.yml'
   workflow_dispatch:  # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
## Summary
Removes path exclusions from the registry sync workflow to ensure it runs on every push to main.

## Problem
The current workflow has path exclusions that prevent it from running when:
- New registries are added to `mcp-registries/`
- Registry configurations are updated
- Only registry-related files are changed

This causes:
- New registry branches not being created automatically
- Registry branches falling behind main
- Manual intervention required to trigger syncs

## Solution
Remove all path exclusions so the workflow triggers on every push to main, ensuring:
- Registry branches stay synchronized with main
- New registries are immediately processed
- No manual triggering needed for registry updates

## Impact
- Workflow will run more frequently (on every main push)
- Registry branches will always be up to date
- Better automation and less manual maintenance

The workflow is designed to handle frequent runs efficiently, so the increased frequency shouldn't cause issues.

🤖 Generated with [Claude Code](https://claude.ai/code)