### PR TITLE
fix: resolve Dependabot configuration issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 10
-    reviewers:
-      - "aaronsb"
     labels:
       - "dependencies"
       - "automated"
@@ -28,8 +26,6 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    reviewers:
-      - "aaronsb"
     labels:
       - "dependencies"
       - "github-actions"
@@ -44,8 +40,6 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    reviewers:
-      - "aaronsb"
     labels:
       - "dependencies"
       - "docker"

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -46,5 +46,6 @@ gh label create "help wanted" -c "008672" -d "Extra attention is needed" 2>/dev/
 gh label create "security" -c "d73a4a" -d "Security related issue" 2>/dev/null || true
 gh label create "breaking change" -c "d73a4a" -d "Breaking change" 2>/dev/null || true
 gh label create "dependencies" -c "0366d6" -d "Pull requests that update a dependency file" 2>/dev/null || true
+gh label create "automated" -c "0366d6" -d "Automated changes by bots" 2>/dev/null || true
 
 echo "Labels setup complete!"


### PR DESCRIPTION
## Summary
- Added missing 'automated' label required by Dependabot
- Removed deprecated 'reviewers' field from dependabot.yml
- Updated setup-labels.sh script to include 'automated' label for future setups

## Changes
- Created 'automated' label for Dependabot PRs
- Updated  to remove deprecated reviewers field (now uses CODEOWNERS)
- Added 'automated' label to Setting up GitHub labels...
Labels setup complete!

## Context
Dependabot reported two issues:
1. Missing required labels: 'automated' and 'dependencies' 
2. Deprecated 'reviewers' field in configuration

This PR resolves both issues to ensure Dependabot can properly create and label pull requests.

## Testing
- Verified both labels now exist in the repository
- Dependabot configuration now follows current best practices