### PR TITLE
feat: prepare for npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,58 @@
+# Source files
+src/
+*.ts
+!build/**/*.d.ts
+
+# Test files
+__tests__/
+*.test.js
+*.test.ts
+jest.config.js
+coverage/
+
+# Development files
+.github/
+.vscode/
+docs/
+scripts/
+resources/
+config/
+
+# Environment and config files
+.env
+.env.*
+*.local.json
+targetprocess.json
+config/targetprocess.json
+
+# Build and development
+tsconfig.json
+.eslintrc.json
+.prettierrc
+.editorconfig
+.gitleaks.toml
+.gitignore
+
+# Docker files
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Logs and temporary files
+*.log
+npm-debug.log*
+.DS_Store
+tmp/
+temp/
+
+# CI/CD
+.travis.yml
+.gitlab-ci.yml
+
+# Repository files
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+CLAUDE.md
+CLAUDE.local.md
+renovate.json
+.git*

--- a/config/personalities/default.json
+++ b/config/personalities/default.json
@@ -1,0 +1,26 @@
+{
+  "id": "default",
+  "name": "Default User",
+  "description": "Default personality with general-purpose semantic operations for all users",
+  "operations": [
+    "search-entities",
+    "get-entity", 
+    "create-entity",
+    "update-entity",
+    "inspect-object"
+  ],
+  "contextualHints": {
+    "emptyResults": "No items found. Try adjusting your search criteria or create a new item.",
+    "errorRecovery": "If you're having trouble, try checking the entity type or field names with inspect_object.",
+    "workflowSuggestions": [
+      "Search for existing items before creating new ones",
+      "Use inspect_object to understand entity structures",
+      "Include related data with the 'include' parameter for richer results"
+    ]
+  },
+  "preferences": {
+    "defaultIncludes": ["Name", "Description", "EntityState"],
+    "preferredViews": ["list", "detail"],
+    "taskOrdering": "priority"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "TargetProcessMCP",
+  "name": "@aaronsb/targetprocess-mcp",
   "version": "0.9.0",
-  "description": "A tool server for Apptio Target Process",
+  "description": "Model Context Protocol server for Targetprocess project management platform",
   "author": "Aaron Bockelie <aaronsb@gmail.com> (https://github.com/aaronsb)",
   "repository": {
     "type": "git",
@@ -15,15 +15,22 @@
     "ai-assistant",
     "claude",
     "agile",
-    "project-management"
+    "project-management",
+    "apptio"
   ],
   "private": false,
   "type": "module",
+  "main": "./build/index.js",
+  "exports": {
+    ".": "./build/index.js"
+  },
   "bin": {
-    "TargetProcessMCP": "./build/index.js"
+    "targetprocess-mcp": "./build/index.js"
   },
   "files": [
-    "build"
+    "build",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "npm run check:secrets && tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
@@ -34,7 +41,10 @@
     "test": "jest",
     "check:secrets": "node scripts/check-secrets.cjs",
     "prebuild": "npm run lint",
-    "precommit": "npm run check:secrets && npm run lint"
+    "precommit": "npm run check:secrets && npm run lint",
+    "prepublishOnly": "npm run test && npm run build",
+    "start": "node build/index.js",
+    "mcp": "node build/index.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.15.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,8 +103,8 @@ export class TargetProcessServer {
   private userRole: string;
 
   constructor() {
-    // Load user role from environment
-    this.userRole = process.env.TP_USER_ROLE || 'developer';
+    // Load user role from environment, default to 'default' for basic semantic operations
+    this.userRole = process.env.TP_USER_ROLE || 'default';
     logger.info(`User role configured as: ${this.userRole}`);
 
     // Initialize service


### PR DESCRIPTION
## Summary
- Update package.json with scoped name @aaronsb/targetprocess-mcp
- Add .npmignore to exclude unnecessary files from npm package  
- Add default personality for users without specific roles
- Configure package scripts for proper npm usage
- Always load semantic operations with intelligent hints

## Changes
- Changed package name to `@aaronsb/targetprocess-mcp` for npm scoping
- Added `.npmignore` file to control which files are published
- Created `config/personalities/default.json` for default user role
- Updated server to default to 'default' role instead of 'developer'
- Added npm scripts: `start`, `mcp`, and `prepublishOnly`
- Enhanced package.json with proper metadata for npm publishing

## Test plan
- [x] Build succeeds with new configuration
- [x] MCP tools work with default personality
- [x] Package scripts run correctly
- [ ] Ready for npm publish (after merge)

🤖 Generated with [Claude Code](https://claude.ai/code)