### PR TITLE
Add automatic pagination system for large responses

### DIFF
--- a/src/tools/pagination/show-all.tool.ts
+++ b/src/tools/pagination/show-all.tool.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import { getFullContent } from '../../utils/paginator.js';
+
+export const showAllToolSchema = z.object({
+  cacheKey: z.string().describe('Cache key from previous paginated result')
+});
+
+export type ShowAllToolInput = z.infer<typeof showAllToolSchema>;
+
+/**
+ * Show all results without pagination
+ */
+export class ShowAllTool {
+  async execute(args: unknown) {
+    const { cacheKey } = showAllToolSchema.parse(args);
+    
+    const fullText = getFullContent(cacheKey);
+    
+    return {
+      content: [{
+        type: 'text',
+        text: fullText
+      }]
+    };
+  }
+}

--- a/src/tools/pagination/show-more.tool.ts
+++ b/src/tools/pagination/show-more.tool.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { getNextPage } from '../../utils/paginator.js';
+
+export const showMoreToolSchema = z.object({
+  cacheKey: z.string().describe('Cache key from previous paginated result'),
+  page: z.number().min(2).optional().describe('Specific page number to show (default: next page)')
+});
+
+export type ShowMoreToolInput = z.infer<typeof showMoreToolSchema>;
+
+/**
+ * Show more results from a paginated response
+ */
+export class ShowMoreTool {
+  async execute(args: unknown) {
+    const { cacheKey, page } = showMoreToolSchema.parse(args);
+    
+    const result = getNextPage(cacheKey, page);
+    
+    return {
+      content: [{
+        type: 'text',
+        text: result.text
+      }]
+    };
+  }
+}

--- a/src/utils/paginator.ts
+++ b/src/utils/paginator.ts
@@ -1,0 +1,122 @@
+/**
+ * Simple text-based pagination utility
+ */
+
+interface PaginationResult {
+  text: string;
+  hasMore: boolean;
+  totalItems: number;
+  cacheKey?: string;
+}
+
+// Simple in-memory cache for pagination
+const paginationCache = new Map<string, string>();
+
+/**
+ * Paginate text content by splitting on natural boundaries
+ */
+export function paginateText(
+  text: string, 
+  maxLines: number = 25,
+  page: number = 1
+): PaginationResult {
+  
+  // Check if this looks like a list (numbered items or bullet points)
+  const lines = text.split('\n');
+  const isNumberedList = lines.some(line => /^\d+\.\s/.test(line.trim()));
+  const isBulletList = lines.some(line => /^[-*•]\s/.test(line.trim()));
+  
+  let items: string[];
+  
+  if (isNumberedList) {
+    // Split on numbered items
+    items = text.split(/(?=\n\d+\.\s)/).filter(item => item.trim());
+  } else if (isBulletList) {
+    // Split on bullet points
+    items = text.split(/(?=\n[-*•]\s)/).filter(item => item.trim());
+  } else {
+    // Split on double newlines (paragraphs) or single lines if short
+    const paragraphs = text.split(/\n\s*\n/).filter(p => p.trim());
+    if (paragraphs.length > 1 && paragraphs.length <= maxLines) {
+      items = paragraphs;
+    } else {
+      // Fall back to line-based splitting
+      items = lines.filter(line => line.trim());
+    }
+  }
+  
+  const totalItems = items.length;
+  
+  // No pagination needed
+  if (totalItems <= maxLines) {
+    return {
+      text,
+      hasMore: false,
+      totalItems
+    };
+  }
+  
+  // Calculate pagination
+  const startIndex = (page - 1) * maxLines;
+  const endIndex = startIndex + maxLines;
+  const pageItems = items.slice(startIndex, endIndex);
+  const hasMore = endIndex < totalItems;
+  
+  // Generate cache key and store full content
+  const cacheKey = `page_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  paginationCache.set(cacheKey, text);
+  
+  // Build paginated text
+  let paginatedText = pageItems.join(isNumberedList || isBulletList ? '' : '\n');
+  
+  // Add pagination footer
+  if (hasMore) {
+    const remaining = totalItems - endIndex;
+    paginatedText += `\n\n--- Showing ${endIndex} of ${totalItems} items ---\n`;
+    paginatedText += `${remaining} more items available. Use show_more with key: ${cacheKey}`;
+  }
+  
+  return {
+    text: paginatedText,
+    hasMore,
+    totalItems,
+    cacheKey: hasMore ? cacheKey : undefined
+  };
+}
+
+/**
+ * Get next page from cache
+ */
+export function getNextPage(cacheKey: string, page: number = 2): PaginationResult {
+  const fullText = paginationCache.get(cacheKey);
+  if (!fullText) {
+    return {
+      text: 'Error: Pagination session expired. Please run your search again.',
+      hasMore: false,
+      totalItems: 0
+    };
+  }
+  
+  return paginateText(fullText, 25, page);
+}
+
+/**
+ * Get full content from cache
+ */
+export function getFullContent(cacheKey: string): string {
+  const fullText = paginationCache.get(cacheKey);
+  return fullText || 'Error: Content not found. Please run your search again.';
+}
+
+/**
+ * Clear old cache entries (called periodically)
+ */
+export function clearOldCache(maxAgeMs: number = 30 * 60 * 1000): void { // 30 minutes
+  const now = Date.now();
+  for (const [key] of paginationCache) {
+    const timestamp = parseInt(key.split('_')[1]) || 0;
+    if (now - timestamp > maxAgeMs) {
+      paginationCache.delete(key);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implemented automatic pagination system that intercepts large responses (>25 lines) to improve readability and reduce context consumption
- Created text-based pagination utility that intelligently detects numbered lists, bullet points, and paragraphs
- Added seamless navigation tools (`show_more` and `show_all`) with cache-based state management

## Technical Details
- **Pagination Logic**: Automatically detects when responses exceed 25 lines and splits content appropriately
- **Content Detection**: Handles numbered lists, bullet points, and paragraph-based content
- **Cache Management**: Uses unique cache keys for maintaining pagination state across tool calls
- **Integration**: Seamlessly integrated into `formatSemanticResult()` without breaking existing functionality

## Test Plan
- [x] Test pagination with large search results (74 work items)
- [x] Verify show_more functionality maintains proper numbering and context
- [x] Confirm show_all displays complete results
- [x] Validate cache key generation and management
- [x] Test with different content types (numbered lists, bullets, paragraphs)

🤖 Generated with [Claude Code](https://claude.ai/code)