### PR TITLE
Improve tool descriptions and fix orderBy parameter handling

### DIFF
--- a/src/api/client/tp.service.ts
+++ b/src/api/client/tp.service.ts
@@ -174,13 +174,16 @@ export class TPService {
 
   /**
    * Formats orderBy parameters according to TargetProcess rules
+   * TargetProcess API only accepts field names, no direction keywords
    */
   private formatOrderBy(orderBy: OrderByOption[]): string {
     return orderBy.map(item => {
       if (typeof item === 'string') {
-        return this.formatWhereField(item);
+        // Remove any direction keywords that might be present
+        const fieldName = item.replace(/\s+(desc|asc)$/i, '').trim();
+        return fieldName; // Don't use formatWhereField for orderBy - just return clean field name
       }
-      return `${this.formatWhereField(item.field)} ${item.direction}`;
+      return item.field; // For object format, just return the field name
     }).join(',');
   }
 

--- a/src/tools/entity/create.tool.ts
+++ b/src/tools/entity/create.tool.ts
@@ -98,7 +98,7 @@ export class CreateEntityTool {
   static getDefinition() {
     return {
       name: 'create_entity',
-      description: 'Create a new Target Process entity. REQUIRED: All entities except Project must have a project.id. OPTIONAL: team, assignedUser for work items.',
+      description: 'Create a new Target Process entity. REQUIRED: All entities except Project must have a project.id. NOTE: Tasks may require a UserStory parent. OPTIONAL: team, assignedUser for work items.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/src/tools/entity/create.tool.ts
+++ b/src/tools/entity/create.tool.ts
@@ -98,7 +98,7 @@ export class CreateEntityTool {
   static getDefinition() {
     return {
       name: 'create_entity',
-      description: 'Create a new Target Process entity',
+      description: 'Create a new Target Process entity. REQUIRED: All entities except Project must have a project.id. OPTIONAL: team, assignedUser for work items.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -119,7 +119,7 @@ export class CreateEntityTool {
             properties: {
               id: {
                 type: 'number',
-                description: 'Project ID (required for all entity types except Project)',
+                description: 'Project ID - REQUIRED for UserStory, Bug, Task, Feature, Epic. NOT used for Project itself.',
               },
             },
             required: ['id'],

--- a/src/tools/entity/get.tool.ts
+++ b/src/tools/entity/get.tool.ts
@@ -88,7 +88,7 @@ export class GetEntityTool {
   static getDefinition() {
     return {
       name: 'get_entity',
-      description: 'Get details of a specific Target Process entity',
+      description: 'Get details of a specific Target Process entity. Use include for related data like ["Project", "AssignedUser", "EntityState", "Priority"].',
       inputSchema: {
         type: 'object',
         properties: {
@@ -105,7 +105,7 @@ export class GetEntityTool {
             items: {
               type: 'string',
             },
-            description: 'Related data to include',
+            description: 'Related data to include. Common values: "Project", "AssignedUser", "EntityState", "Priority", "Team". Avoid complex nested includes.',
           },
           allow_informative_errors: {
             type: 'boolean',

--- a/src/tools/inspect/inspect.tool.ts
+++ b/src/tools/inspect/inspect.tool.ts
@@ -364,13 +364,13 @@ export class InspectObjectTool {
   static getDefinition() {
     return {
       name: 'inspect_object',
-      description: 'Inspect Target Process objects and properties through the API. This tool also provides API discovery capabilities through error messages when used with unsupported entity types.',
+      description: 'Inspect TargetProcess API metadata. Use "list_types" to see all entity types, "get_properties" to see fields for an entity type, "discover_api_structure" for quick entity discovery.',
       inputSchema: {
         type: 'object',
         properties: {
           action: {
             type: 'string',
-            description: 'Action to perform: list_types, get_properties, get_property_details, or discover_api_structure',
+            description: 'Action: "list_types" (all entities), "get_properties" (fields for entity), "get_property_details" (field details), "discover_api_structure" (quick discovery)',
           },
           entityType: {
             type: 'string',

--- a/src/tools/search/search.tool.ts
+++ b/src/tools/search/search.tool.ts
@@ -41,7 +41,7 @@ export const searchToolSchema = z.object({
   where: z.string().optional().describe('Filter expression using TargetProcess query language.\n\nPreset filters: searchPresets.open, .notDone, .myOpenTasks, .activeItems, etc.\n\nQuery syntax:\n- Use "eq" for equals: EntityState.Name eq "Open"\n- Use "ne" for not equals: EntityState.Name ne "Done"\n- Use "and"/"or": Priority.Name eq "High" and EntityState.Name ne "Done"\n- Date macros: CreateDate gt @Today\n\nExample: searchPresets.activeItems or "EntityState.Name ne \'Done\'"'),
   include: z.array(z.string()).optional().describe('Related data to include (e.g., Project, Team, AssignedUser)'),
   take: z.number().min(1).max(1000).optional().describe('Number of items to return (default: 100)'),
-  orderBy: z.array(z.string()).optional().describe('Fields to sort by (e.g., ["CreateDate desc"])'),
+  orderBy: z.array(z.string()).optional().describe('Fields to sort by - field names only (e.g., ["CreateDate", "Name"]). Note: TargetProcess API does not support direction keywords like "desc" or "asc".'),
 });
 
 export type SearchToolInput = z.infer<typeof searchToolSchema>;
@@ -113,7 +113,7 @@ export class SearchTool {
   static getDefinition() {
     return {
       name: 'search_entities',
-      description: 'Search Target Process entities with powerful filtering capabilities and preset filters for common scenarios',
+      description: 'Search Target Process entities with powerful filtering capabilities and preset filters for common scenarios. Common usage patterns: basic search by type only, preset filters for status/assignments, simple field-only sorting.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -125,7 +125,7 @@ export class SearchTool {
             type: 'string',
             description: `Filter expression using Target Process query language. Common preset filters available:
 - Status filters: searchPresets.open, .inProgress, .done
-- Assignment filters: searchPresets.myTasks, .unassigned
+- Assignment filters: searchPresets.myTasks, .unassigned  
 - Time-based filters: searchPresets.createdToday, .modifiedToday, .createdThisWeek
 - Priority filters: searchPresets.highPriority
 - Combined filters: searchPresets.myOpenTasks, .highPriorityUnassigned
@@ -137,7 +137,7 @@ Example: searchPresets.open or "EntityState.Name eq 'Open'"`,
             items: {
               type: 'string',
             },
-            description: 'Related data to include in results (e.g., ["Project", "Team", "AssignedUser"])',
+            description: 'Related data to include in results. Common reliable options: ["Project", "AssignedUser", "EntityState", "Priority"]. AVOID: Complex nested includes that may cause errors.',
           },
           take: {
             type: 'number',
@@ -150,7 +150,7 @@ Example: searchPresets.open or "EntityState.Name eq 'Open'"`,
             items: {
               type: 'string',
             },
-            description: 'Sort order for results (e.g., ["CreateDate desc", "Name asc"])',
+            description: 'Fields to sort by - field names only (e.g., ["CreateDate", "Name"]). TargetProcess API does not support "desc" or "asc" keywords.',
           },
         },
         required: ['type'],

--- a/src/tools/update/update.tool.ts
+++ b/src/tools/update/update.tool.ts
@@ -73,7 +73,7 @@ export class UpdateEntityTool {
   static getDefinition() {
     return {
       name: 'update_entity',
-      description: 'Update an existing Target Process entity',
+      description: 'Update an existing Target Process entity. Common updates: name, description, status (requires status.id), assignedUser (requires user.id).',
       inputSchema: {
         type: 'object',
         properties: {
@@ -101,7 +101,7 @@ export class UpdateEntityTool {
                 properties: {
                   id: {
                     type: 'number',
-                    description: 'Status ID to set',
+                    description: 'Status ID to set (must be valid EntityState ID for this entity type)',
                   },
                 },
                 required: ['id'],


### PR DESCRIPTION
## Summary
- Fixed critical orderBy parameter handling that was causing "Error during parameters parsing" errors
- Enhanced tool descriptions across 5 core MCP tools to provide clearer guidance and prevent common agent errors
- Preserved and promoted working searchPresets for better agent success rates

## Technical Changes

### Critical Bug Fix
- **Fixed orderBy parameter handling** in `tp.service.ts` to strip direction keywords (`desc`/`asc`) and only send field names to the TargetProcess API, resolving parsing errors

### Tool Description Improvements
- **create_entity**: Added clear project.id requirements and field usage guidance, plus note about Task creation requirements
- **get_entity**: Added common include field examples and usage patterns
- **update_entity**: Added status ID validation notes and common update patterns  
- **inspect_object**: Clarified workflow examples and action explanations
- **search_entities**: Enhanced with reliable parameter guidance and error prevention notes

## Benefits
- **Reduced Agent Errors**: Clear parameter requirements prevent common validation failures
- **Better Success Rates**: Practical examples and working preset filters improve tool usage
- **Clearer Guidance**: Explicit field requirements and usage patterns reduce confusion
- **Error Prevention**: Warnings about complex parameters that may cause API errors

## Known Issues to Address
Testing revealed some entity creation requirements that need systematic investigation:
- Task creation returned "UserStory should be specified" suggesting hierarchy requirements
- Need to systematically map entity creation requirements across all types

## Test Plan
- [x] Test orderBy with field names only (no parsing errors)
- [x] Verify searchPresets continue to work properly
- [x] Test improved tool descriptions provide clearer guidance
- [x] Confirm include field examples work as documented
- [x] Validate error prevention warnings are accurate

🤖 Generated with [Claude Code](https://claude.ai/code)