### PR TITLE
fix: remove unused variables in test file

### DIFF
--- a/src/__tests__/tools/search.tool.test.ts
+++ b/src/__tests__/tools/search.tool.test.ts
@@ -145,7 +145,7 @@ describe('SearchTool', () => {
       const mockBugs = [];
       mockService.searchEntities.mockResolvedValue(mockBugs);
 
-      const result = await searchTool.execute({
+      await searchTool.execute({
         type: 'Bug',
         where: 'searchPresets.highPriority',
         take: 5
@@ -164,7 +164,7 @@ describe('SearchTool', () => {
       const mockTasks = [];
       mockService.searchEntities.mockResolvedValue(mockTasks);
 
-      const result = await searchTool.execute({
+      await searchTool.execute({
         type: 'Task',
         where: 'searchPresets.createdToday',
         take: 5


### PR DESCRIPTION
## Summary
Removes unused variables that were flagged by CodeQL after PR #205 was merged.

## Changes
- Remove unused 'result' variables in two test cases in `search.tool.test.ts`
- Addresses CodeQL warnings from GitHub Advanced Security

## Context
These warnings appeared after PR #205 was merged. This is a quick cleanup to address the code scanning findings.

## Testing
- [x] Tests still pass
- [x] Linting passes
- [x] No functional changes, only removing unused variable assignments